### PR TITLE
msm8998-common: overlay: Enable config_performantAuthDefault

### DIFF
--- a/overlay/frameworks/base/core/res/res/values/config.xml
+++ b/overlay/frameworks/base/core/res/res/values/config.xml
@@ -335,4 +335,7 @@
     <string name="config_smartChargingSysfsNode" translatable="false">/sys/class/power_supply/battery/input_suspend</string>
     <string name="config_smartChargingSuspendValue" translatable="false">1</string>
     <string name="config_smartChargingResumeValue" translatable="false">0</string>
+
+    <!-- Default value for performant auth feature. -->
+    <bool name="config_performantAuthDefault">true</bool>
 </resources>


### PR DESCRIPTION
We don't have a fp sensor on power button, but we DO want the option for touching the fp sensor to wake the screen and unlock to be visible.

Change-Id: I8e7385fd2217e5fb14619dce0a7cc6c8e13a9205